### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,4 +27,4 @@ Authors
 
 Invenio module that adds GitHub integration to the platform.
 
-- CERN <info@invenio-software.org>
+- CERN <info@inveniosoftware.org>

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-GitHub.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-github
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ directory = invenio_github/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_github/translations/messages.pot
 add-comments = NOTE

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     keywords='invenio github',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-github',
     packages=packages,
     zip_safe=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,7 +159,7 @@ def tester_id(app, db):
     """Fixture that contains the test data for models tests."""
     datastore = app.extensions['security'].datastore
     tester = datastore.create_user(
-        email='info@invenio-software.org', password='tester',
+        email='info@inveniosoftware.org', password='tester',
     )
     db.session.commit()
     return tester.id

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -33,7 +33,7 @@ def register_github_api():
     register_oauth_flow()
     register_endpoint(
         '/user',
-        USER('auser', email='auser@invenio-software.org')
+        USER('auser', email='auser@inveniosoftware.org')
     )
     register_endpoint(
         '/user/orgs',
@@ -80,7 +80,7 @@ def register_github_api():
     )
     register_endpoint(
         '/users/auser',
-        USER('auser', email='auser@invenio-software.org')
+        USER('auser', email='auser@inveniosoftware.org')
     )
     register_endpoint(
         '/users/buser',
@@ -88,7 +88,7 @@ def register_github_api():
     )
     register_endpoint(
         '/users/cuser',
-        USER('cuser', email='cuser@invenio-software.org')
+        USER('cuser', email='cuser@inveniosoftware.org')
     )
     register_endpoint(
         '/user/repos',

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -124,13 +124,13 @@ def test_no_public_email(app, db):
                 'invenio_oauthclient.signup',
                 remote_app='github',
             ),
-            data={'email': 'noemailuser@invenio-software.org'}
+            data={'email': 'noemailuser@inveniosoftware.org'}
         )
         assert resp.location.endswith('/mytest/')
 
         from invenio_accounts.models import User
         assert User.query.filter_by(
-            email='noemailuser@invenio-software.org'
+            email='noemailuser@inveniosoftware.org'
         ).count() == 1
 
     httpretty.disable()


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>