### PR TITLE
templates: release link generation fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,6 @@
 Changes
 =======
 
-Version v1.0.0a4 (released 2016-09-06)
+Version v1.0.0a5 (released 2016-09-12)
 
 - Initial public release.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 =========================
- Invenio-GitHub v1.0.0a4
+ Invenio-GitHub v1.0.0a5
 =========================
 
-Invenio-GitHub v1.0.0a4 was released on September 6, 2016.
+Invenio-GitHub v1.0.0a5 was released on September 12, 2016.
 
 About
 -----
@@ -19,7 +19,7 @@ What's new
 Installation
 ------------
 
-   $ pip install invenio-github==v1.0.0a4
+   $ pip install invenio-github==v1.0.0a5
 
 Documentation
 -------------

--- a/invenio_github/templates/invenio_github/settings/view.html
+++ b/invenio_github/templates/invenio_github/settings/view.html
@@ -127,9 +127,9 @@ require(['jquery', 'js/github/view'], function($, view) {
               </p>
               {%- endif %}
               <p>
-                <a href="{{release.event.payload.release.html_url}}" class="text-muted">
+                <a href="{{release.event.payload.release.html_url if release.event else 'https://github.com/{0}/releases/tag/{1}'.format(repo.name, release.tag)}}" class="text-muted">
                   <i class="fa fa-fw fa-github"></i>
-                  {{release.event.payload.release.name}}
+                  {{release.event.payload.release.name if release.event else release.tag}}
                 </a>
               </p>
               {%- endblock release_title %}

--- a/invenio_github/version.py
+++ b/invenio_github/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0a4"
+__version__ = "1.0.0a5"


### PR DESCRIPTION
* Generates GitHub release link manually in case of missing event data.

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>