### PR TITLE
Template: remove the translation of the release title

### DIFF
--- a/invenio_github/templates/invenio_github/settings/view.html
+++ b/invenio_github/templates/invenio_github/settings/view.html
@@ -139,7 +139,7 @@ require(['jquery', 'js/github/view'], function($, view) {
             <h5>
               <i class="fa {{ release.model.status.icon }}"></i>
               <a href="#" data-toggle="collapse" data-target="#{{ release.model.id }}">
-              {{_(release.model.status.title)}}
+              {{release.model.status.title}}
               </a>
             </h5>
             <small class="text-muted">{{ release.model.created|naturaltime }}</small>


### PR DESCRIPTION
I had some error from the gettext library trying to translate the release.model.status.title.
Honestly i don't know exactly what causes the error, anyway I think the release title should not be translated, so we can just remove the translation.