### PR TITLE
fix: use GitHub payload for title

### DIFF
--- a/invenio_github/api.py
+++ b/invenio_github/api.py
@@ -354,12 +354,10 @@ class GitHubRelease(object):
     @cached_property
     def title(self):
         """Extract title from a release."""
-        if self.event:
-            if self.release['name']:
-                return u'{0}: {1}'.format(
-                    self.repository['full_name'], self.release['name']
-                )
-        return u'{0} {1}'.format(self.repo_model.name, self.model.tag)
+        repo_name = self.repository.get('full_name', self.repo_model.name)
+        release_name = self.release.get(
+            'name', self.release.get('tag_name', self.model.tag))
+        return u'{0}: {1}'.format(repo_name, release_name)
 
     @cached_property
     def description(self):


### PR DESCRIPTION
 * uses repository name from GitHub payload instead of the first repo name we've got from GitHub. The problem was that, if the release has no name, we were using the first name we collected for the repo. If the repo's name changed over time, the title would be incorrect.