### PR TITLE
api: fixed issue with release names being None or empty.

### DIFF
--- a/invenio_github/api.py
+++ b/invenio_github/api.py
@@ -372,7 +372,7 @@ class GitHubRelease(object):
         """Extract title from a release."""
         repo_name = self.repository.get('full_name', self.repo_model.name)
         release_name = self.release.get(
-            'name', self.release.get('tag_name', self.model.tag))
+            'name') or self.release.get('tag_name', self.model.tag)
         return u'{0}: {1}'.format(repo_name, release_name)
 
     @cached_property


### PR DESCRIPTION
closes https://github.com/zenodo/ops/issues/192

See the following [record](https://zenodo.org/record/6534555) on Zenodo.

The record name is "None" as the record name is derived from the `payload.event.release`. For this specific release, we received the following `name` attribute in the payload:

```json
{
  'action': 'published',
  'release': {
    'name': None,
  }
}
```

We also have scenarios on which the payload is sent with an empty string as a the release `name` attribute. Such cases are not handled properly, see the following [record](https://zenodo.org/record/6419641).

The difference between receiving an empty string `""` or `None` is on Github's side.