### PR TITLE
api: removed gh contributors unauthenticated fetching.

### DIFF
--- a/invenio_github/errors.py
+++ b/invenio_github/errors.py
@@ -139,3 +139,13 @@ class ReleaseNotFound(GitHubError):
     def __init__(self, message=None):
         """Constructor."""
         super().__init__(message or self.message)
+
+
+class UnexpectedGithubResponse(GitHubError):
+    """Request to Github API returned an unexpected error."""
+
+    message = "Github API returned an unexpected error."
+
+    def __init__(self, message=None):
+        """Constructor."""
+        super().__init__(message or self.message)

--- a/invenio_github/tasks.py
+++ b/invenio_github/tasks.py
@@ -52,7 +52,7 @@ def release_gh_metadata_handler(release, ex):
 
 def release_default_exception_handler(release, ex):
     """Default handler."""
-    release.release_object.errors = _get_err_obj("Unknown error occured.")
+    release.release_object.errors = _get_err_obj(ex.message)
     db.session.commit()
 
 


### PR DESCRIPTION
closes https://github.com/zenodo/rdm-project/issues/362

Previously we fetched contributors from github through an API request, but we don't use the authenticated API session. 


`github3` already exposes the user information if the `Contributor` object is expanded (`Contributor.refresh()`)

When the API request to Github goes wrong, I added a `raise` so it is clearer what happened. 
