### PR TITLE
api: added session timeout to fetch zipball.

### DIFF
--- a/invenio_github/api.py
+++ b/invenio_github/api.py
@@ -639,7 +639,8 @@ class GitHubRelease(object):
     def fetch_zipball_file(self):
         """Fetch release zipball file using the current github session."""
         session = self.gh.api.session
-        with session.get(self.release_zipball_url, stream=True) as s:
+        timeout = current_app.config.get("GITHUB_ZIPBALL_TIMEOUT", 300)
+        with session.get(self.release_zipball_url, stream=True, timeout=timeout) as s:
             yield s.raw
 
     def publish(self):

--- a/invenio_github/config.py
+++ b/invenio_github/config.py
@@ -82,3 +82,6 @@ GITHUB_CITATION_FILE = None
 
 GITHUB_CITATION_METADATA_SCHEMA = None
 """Citation metadata schema."""
+
+GITHUB_ZIPBALL_TIMEOUT = 300
+"""Timeout for the zipball download, in seconds."""


### PR DESCRIPTION
Big files fail due to a default timeout from github 3 session (10 seconds). 