### PR TITLE
fix(chore): DeprecationWarning stdlib

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 ..
     This file is part of Invenio.
     Copyright (C) 2016-2025 CERN.
-    Copyright (C) 2024-2025 Graz University of Technology.
+    Copyright (C) 2024-2026 Graz University of Technology.
 
     Invenio is free software; you can redistribute it
     and/or modify it under the terms of the GNU General Public License as
@@ -25,6 +25,13 @@
 
 Changes
 =======
+
+Version v5.0.0 (released 2026-01-29)
+
+- chore(black): update formatting to >= 26.0
+- chore(setup): bump dependencies
+- fix(chore): DeprecationWarning stdlib
+- Update release date for version v4.0.0
 
 Version v4.0.0 (released 2025-11-12)
 

--- a/invenio_github/__init__.py
+++ b/invenio_github/__init__.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2023-2025 CERN.
-# Copyright (C) 2024-2025 Graz University of Technology.
+# Copyright (C) 2024-2026 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -27,6 +27,6 @@
 
 from .ext import InvenioGitHub
 
-__version__ = "4.0.0"
+__version__ = "5.0.0"
 
 __all__ = ("__version__", "InvenioGitHub")

--- a/invenio_github/alembic/2f62e6442a08_change_datetime_types.py
+++ b/invenio_github/alembic/2f62e6442a08_change_datetime_types.py
@@ -1,0 +1,34 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2026 Graz University of Technology.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Change expires_at type to utc aware datetime."""
+
+from invenio_db.utils import (
+    update_table_columns_column_type_to_datetime,
+    update_table_columns_column_type_to_utc_datetime,
+)
+
+# revision identifiers, used by Alembic.
+revision = "2f62e6442a08"
+down_revision = "b0eaee37b545"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    for table_name in ["github_repositories", "github_releases"]:
+        update_table_columns_column_type_to_utc_datetime(table_name, "created")
+        update_table_columns_column_type_to_utc_datetime(table_name, "updated")
+
+
+def downgrade():
+    """Downgrade database."""
+    for table_name in ["github_repositories", "github_releases"]:
+        update_table_columns_column_type_to_datetime(table_name, "created")
+        update_table_columns_column_type_to_datetime(table_name, "updated")

--- a/invenio_github/models.py
+++ b/invenio_github/models.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2023 CERN.
+# Copyright (C) 2026 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -32,7 +33,6 @@ from invenio_db import db
 from invenio_i18n import lazy_gettext as _
 from invenio_webhooks.models import Event
 from sqlalchemy.dialects import postgresql
-from sqlalchemy_utils.models import Timestamp
 from sqlalchemy_utils.types import ChoiceType, JSONType, UUIDType
 
 RELEASE_STATUS_TITLES = {
@@ -107,7 +107,7 @@ class ReleaseStatus(Enum):
         return RELEASE_STATUS_COLOR[self.name]
 
 
-class Repository(db.Model, Timestamp):
+class Repository(db.Model, db.Timestamp):
     """Information about a GitHub repository."""
 
     __tablename__ = "github_repositories"
@@ -203,7 +203,7 @@ class Repository(db.Model, Timestamp):
         return "<Repository {self.name}:{self.github_id}>".format(self=self)
 
 
-class Release(db.Model, Timestamp):
+class Release(db.Model, db.Timestamp):
     """Information about a GitHub release."""
 
     __tablename__ = "github_releases"

--- a/invenio_github/oauth/remote_app.py
+++ b/invenio_github/oauth/remote_app.py
@@ -6,7 +6,6 @@
 # it under the terms of the MIT License; see LICENSE file for more details.
 """Github oauth app implementation for github integration."""
 
-
 from invenio_oauthclient.contrib.github import GitHubOAuthSettingsHelper
 
 from invenio_github.oauth.handlers import account_setup_handler, disconnect_handler

--- a/invenio_github/tasks.py
+++ b/invenio_github/tasks.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2023 CERN.
 # Copyright (C) 2024 KTH Royal Institute of Technology.
+# Copyright (C) 2026 Graz University of Technology.
 #
 # Invenio is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -154,7 +155,7 @@ def refresh_accounts(expiration_threshold=None):
     :param expiration_threshold: Dictionary containing timedelta parameters
     referring to the maximum inactivity time.
     """
-    expiration_date = datetime.datetime.utcnow() - datetime.timedelta(
+    expiration_date = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
         **(expiration_threshold or {"days": 6 * 30})
     )
 

--- a/invenio_github/utils.py
+++ b/invenio_github/utils.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2023 CERN.
+# Copyright (C) 2026 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,17 +20,16 @@
 
 """Various utility functions."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import dateutil.parser
-import pytz
 import six
 from werkzeug.utils import import_string
 
 
 def utcnow():
     """UTC timestamp (with timezone)."""
-    return datetime.now(tz=pytz.utc)
+    return datetime.now(tz=timezone.utc)
 
 
 def iso_utcnow():
@@ -41,7 +41,7 @@ def parse_timestamp(x):
     """Parse ISO8601 formatted timestamp."""
     dt = dateutil.parser.parse(x)
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=pytz.utc)
+        dt = dt.replace(tzinfo=timezone.utc)
     return dt
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2023-2025 CERN.
-# Copyright (C) 2023-2025 Graz University of Technology.
+# Copyright (C) 2023-2026 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -49,17 +49,17 @@ install_requires =
     github3.py>=4.0.1,<5.0.0
     humanize>=0.5.1
     invenio-assets>=4.0.0,<5.0.0
-    invenio-accounts>=6.0.0,<7.0.0
+    invenio-accounts>=7.0.0,<8.0.0
     invenio-celery>=2.0.0,<3.0.0
-    invenio-db>=2.0.0,<3.0.0
-    invenio-formatter>=3.0.0,<4.0.0
+    invenio-db>=2.2.0,<3.0.0
+    invenio-formatter>=4.0.0,<5.0.0
     invenio-i18n>=3.0.0,<4.0.0
-    invenio-oauth2server>=3.0.0,<4.0.0
-    invenio-oauthclient>=6.0.0,<7.0.0
-    invenio-pidstore>=2.0.0,<3.0.0
-    invenio-records-rest>=3.0.0,<4.0.0
-    invenio-webhooks>=1.0.0,<2.0.0
-    invenio-records-resources>=8.0.0,<9.0.0
+    invenio-oauth2server>=4.0.0,<5.0.0
+    invenio-oauthclient>=7.0.0,<8.0.0
+    invenio-pidstore>=3.0.0,<4.0.0
+    invenio-records-rest>=4.0.0,<5.0.0
+    invenio-webhooks>=2.0.0,<3.0.0
+    invenio-records-resources>=9.0.0,<10.0.0
     mistune>=0.7.2
     six>=1.12.0
     uritemplate>=3.0.1
@@ -67,13 +67,13 @@ install_requires =
 [options.extras_require]
 tests =
     httpretty>=0.8.14
-    invenio-app>=2.0.0,<3.0.0
-    invenio-db[postgresql,mysql]>=2.0.0,<3.0.0
-    invenio-files-rest>=3.0.0,<4.0.0
+    invenio-app>=3.0.0,<4.0.0
+    invenio-db[postgresql,mysql]>=2.2.0,<3.0.0
+    invenio-files-rest>=4.0.0,<5.0.0
     isort>=4.2.2
     mock>=2.0.0
-    pytest-black-ng>=0.4.0
-    pytest-invenio>=3.0.0,<4.0.0
+    pytest-black>=0.6.0
+    pytest-invenio>=4.0.0,<5.0.0
     pytest-mock>=2.0.0
     sphinx>=4.5.0
 elasticsearch7 =

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -21,6 +21,7 @@
 # or submit itself to any jurisdiction.
 
 """Define fixtures for tests."""
+
 import os
 from base64 import b64encode
 from zipfile import ZipFile

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -5,6 +5,7 @@
 # Invenio-Github is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 """Test invenio-github views."""
+
 from flask_security import login_user
 from invenio_accounts.testutils import login_user_via_session
 from invenio_oauthclient.models import RemoteAccount


### PR DESCRIPTION
* datetime.datetime.utcnow() is deprecated and scheduled for removal in
  a future version. Use timezone-aware objects to represent datetimes in
  UTC: datetime.datetime.now(datetime.UTC).

* the decision was made to move to utc aware timestamps
