### PR TITLE
Fix linking Github as external identifier

### DIFF
--- a/invenio_github/api.py
+++ b/invenio_github/api.py
@@ -157,6 +157,7 @@ class GitHubAPI(object):
             )
 
         ghuser = self.api.me()
+        emails = list(self.api.emails())
         # Setup local access tokens to be used by the webhooks
         hook_token = ProviderToken.create_personal(
             "github-webhook",
@@ -169,6 +170,7 @@ class GitHubAPI(object):
             id=ghuser.id,
             login=ghuser.login,
             name=ghuser.name,
+            email=next((e.email for e in emails if e.verified and e.primary), None),
             tokens=dict(
                 webhook=hook_token.id,
             ),

--- a/invenio_github/oauth/handlers.py
+++ b/invenio_github/oauth/handlers.py
@@ -24,23 +24,49 @@
 
 from flask import current_app, redirect, url_for
 from flask_login import current_user
+from invenio_accounts.errors import AlreadyLinkedError
+from invenio_accounts.models import UserIdentity
 from invenio_db import db
 from invenio_oauth2server.models import Token as ProviderToken
-from invenio_oauthclient import oauth_unlink_external_id
+from invenio_oauthclient import oauth_link_external_id, oauth_unlink_external_id
 
 from invenio_github.api import GitHubAPI
-from invenio_github.tasks import disconnect_github
+from invenio_github.tasks import disconnect_github, sync_account
 
 
 def account_setup_handler(remote, token, resp):
     """Perform post initialization."""
+    account = token.remote_account
     try:
-        gh = GitHubAPI(user_id=token.remote_account.user_id)
+        gh = GitHubAPI(user_id=account.user_id)
         gh.init_account()
+
+        # Link the identity (and commit) before the repo sync, so we don't end up with
+        # an unlinked account
+        gh_id = str(account.extra_data["id"])
+        existing = UserIdentity.query.filter_by(
+            method=remote.name, id=gh_id
+        ).one_or_none()
+        if existing is not None and existing.id_user == account.user_id:
+            return
+        oauth_link_external_id(account.user, {"id": gh_id, "method": remote.name})
+        db.session.commit()
+    except AlreadyLinkedError:
+        # The GitHub ID belongs to another user, or this user is already linked to a
+        # different GitHub ID. Surface it so the OAuth flow flashes a message, and the
+        # user resolves it by unlinking first.
+        raise
+    except Exception:
+        current_app.logger.exception("Failed to link GitHub identity")
+        return
+
+    # Sync repos/hooks, and retry asynchronously on failure
+    try:
         gh.sync()
         db.session.commit()
-    except Exception as e:
-        current_app.logger.warning(str(e), exc_info=True)
+    except Exception:
+        current_app.logger.exception("Failed to sync GitHub account")
+        sync_account.delay(account.user_id)
 
 
 def disconnect_handler(remote):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,6 +232,26 @@ def _create_github_api_mock(
         github_user_metadata(login="auser", email="auser@inveniosoftware.org"),
         mock_api.session,
     )
+    mock_api.emails.return_value = [
+        github3.users.Email(
+            {
+                "email": "auser@inveniosoftware.org",
+                "primary": True,
+                "verified": True,
+                "visibility": "public",
+            },
+            mock_api.session,
+        ),
+        github3.users.Email(
+            {
+                "email": "secondary@inveniosoftware.org",
+                "primary": False,
+                "verified": False,
+                "visibility": None,
+            },
+            mock_api.session,
+        ),
+    ]
 
     repo_1 = github3.repos.Repository(
         github_repo_metadata(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,10 +11,13 @@ import time
 from unittest.mock import patch
 
 import pytest
+from invenio_accounts.errors import AlreadyLinkedError
+from invenio_accounts.models import UserIdentity
 from invenio_webhooks.models import Event
 
 from invenio_github.api import GitHubAPI, GitHubRelease
 from invenio_github.models import Release, ReleaseStatus, Repository
+from invenio_github.oauth.handlers import account_setup_handler
 
 from .fixtures import PAYLOAD as github_payload_fixture
 
@@ -29,6 +32,84 @@ def test_github_api_create_hook(app, test_user, github_api):
     repo_name = "repo-1"
     hook_created = api.create_hook(repo_id=repo_id, repo_name=repo_name)
     assert hook_created
+
+
+def test_account_setup_handler_links_external_id(
+    app, db, github_remote_app, remote_token, github_api
+):
+    """Setup handler links the GitHub identity to the user via UserIdentity."""
+    user_id = remote_token.remote_account.user_id
+
+    # No external-id link exists before setup runs.
+    assert UserIdentity.query.filter_by(method="github", id_user=user_id).count() == 0
+
+    account_setup_handler(github_remote_app, remote_token, resp=None)
+
+    # The mock GitHub user id (1234) is now linked, so future logins resolve
+    # by external id instead of falling back to email matching.
+    identity = UserIdentity.query.filter_by(
+        method="github", id="1234", id_user=user_id
+    ).one_or_none()
+    assert identity is not None
+
+
+def test_account_setup_handler_idempotent_for_same_user(
+    app, db, github_remote_app, remote_token, github_api
+):
+    """Re-running setup when already linked to the same user is a no-op."""
+    user_id = remote_token.remote_account.user_id
+    UserIdentity.create(remote_token.remote_account.user, "github", "1234")
+    db.session.commit()
+
+    account_setup_handler(github_remote_app, remote_token, resp=None)
+
+    assert (
+        UserIdentity.query.filter_by(
+            method="github", id="1234", id_user=user_id
+        ).count()
+        == 1
+    )
+
+
+def test_account_setup_handler_conflict_other_user(
+    app, db, github_remote_app, remote_token, github_api, unlinked_user
+):
+    """A GitHub id already linked to another user raises and is left intact."""
+    UserIdentity.create(unlinked_user, "github", "1234")
+    db.session.commit()
+
+    with pytest.raises(AlreadyLinkedError):
+        account_setup_handler(github_remote_app, remote_token, resp=None)
+
+    # The link still points to the other user; the token's user got none.
+    owner = UserIdentity.query.filter_by(method="github", id="1234").one()
+    assert owner.id_user == unlinked_user.id
+    assert (
+        UserIdentity.query.filter_by(
+            method="github", id_user=remote_token.remote_account.user_id
+        ).count()
+        == 0
+    )
+
+
+def test_account_setup_handler_links_before_sync(
+    app, db, github_remote_app, remote_token, github_api
+):
+    """A sync failure does not undo the link; a retry task is scheduled instead."""
+    user_id = remote_token.remote_account.user_id
+
+    with (
+        patch.object(GitHubAPI, "sync", side_effect=Exception("boom")),
+        patch("invenio_github.oauth.handlers.sync_account") as sync_task,
+    ):
+        account_setup_handler(github_remote_app, remote_token, resp=None)
+
+    # Linked despite the sync failure...
+    assert UserIdentity.query.filter_by(
+        method="github", id="1234", id_user=user_id
+    ).one_or_none()
+    # ...and a retry was scheduled.
+    sync_task.delay.assert_called_once_with(user_id)
 
 
 # GithubRelease api tests

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -112,6 +112,17 @@ def test_account_setup_handler_links_before_sync(
     sync_task.delay.assert_called_once_with(user_id)
 
 
+def test_init_account_stores_matched_email(app, test_user, github_api):
+    """init_account stores the verified+primary email, not the full list or profile."""
+    api = GitHubAPI(test_user.id)
+    api.init_account()
+    extra = api.account.extra_data
+
+    assert extra["email"] == "auser@inveniosoftware.org"
+    assert "emails" not in extra
+    assert "profile" not in extra
+
+
 # GithubRelease api tests
 
 


### PR DESCRIPTION
- **fix(oauth): link GitHub identity to user on account setup**
  The GitHub setup handler overrode invenio-oauthclient's account_setup
  but dropped its oauth_link_external_id call, so the UserIdentity link
  between the user and their GitHub identity was never created. Without
  it, oauth_get_user can't match by external id and falls back to email
  matching, producing duplicate accounts when a user's email no longer
  matches their GitHub primary email, and risking cross-account login.

  Recreate the link after init_account/sync, guarded against re-linking,
  mirroring the equivalent invenio-vcs fix in its init_account.
  

- **feat(github): store matched email in account extra_data**
  init_account already records the login and name we use for the user's
  account/profile; this adds the verified+primary email GitHub returns,
  which is the address used to match/register the local user. We store
  only that identity data, not the full email list or the GitHub profile
  blob (bio, company, location, blog, avatar).
  