### PR TITLE
fix(github): default_branch when no github_id

### DIFF
--- a/invenio_github/templates/semantic-ui/invenio_github/settings/view.html
+++ b/invenio_github/templates/semantic-ui/invenio_github/settings/view.html
@@ -229,7 +229,7 @@
                           <div id="citation-{{ loop.index }}-tab-panel" role="tabpanel" class="ui tab rel-p-1 {{ 'active' if active }}" data-tab="citation-{{ loop.index }}">
                             {%- block releasetab_cff %}
                               {% set repo_name = value %}
-                              {% set citation_cff_create_link = 'https://github.com/{0}/new/{1}?filename=CITATION.cff'.format(repo.name, (default_branch or 'master')) %}
+                              {% set citation_cff_create_link = 'https://github.com/{0}/new/{1}?filename=CITATION.cff'.format(repo.name, default_branch) %}
                               <div class="flex align-items-center justify-space-between rel-mb-1">
                                 <h3 class="ui header m-0">{{ _("Citation File") }}</h3>
                                 <a class="ui basic button" href="{{ citation_cff_create_link }}">

--- a/invenio_github/views/github.py
+++ b/invenio_github/views/github.py
@@ -121,8 +121,8 @@ def register_ui_routes(blueprint):
             latest_release = github.repo_last_published_release(repo)
             default_branch = (
                 github.account.extra_data.get("repos", {})
-                .get(str(repo.github_id), None)
-                .get("default_branch", None)
+                .get(str(repo.github_id), {})
+                .get("default_branch", "master")
             )
             releases = github.get_repository_releases(repo=repo)
             return render_template(


### PR DESCRIPTION

:heart: Thank you for your contribution!

### Description

When a given github_id is not present in the extra_data's repos, assigning a default_branch would fail. In theory, a default_branch = None would then default to 'master' in
templates/semantic-ui/settings/views.html

This fix ensures, if the given repo is not in the extra_data repos, default_branch will correctly default to 'master', and keeps this logic entirely within `get_repository()`.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).



**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
